### PR TITLE
2CV argument to tve_path

### DIFF
--- a/R/tve_path.R
+++ b/R/tve_path.R
@@ -5,9 +5,13 @@
 #' between the two, though primarily from Windows to Mac.
 #'
 #' @param path File path to be converted
+#' @param dtag_company whether file path is for tve or 2cv
 #'
 #' @export
-tve_path <- function(path) {
+tve_path <- function(path,
+                     dtag_company = "tve") {
+
+  if (dtag_company == "tve") {
   if(.Platform$OS.type == "unix") {
     # if unix then replace Z:/ in the filepath
     gsub(
@@ -28,3 +32,26 @@ tve_path <- function(path) {
     )
   }
 }
+  else if (dtag_company == "2cv") {
+    # if not tve then return the path as is
+    if(.Platform$OS.type == "unix") {
+      # if unix then replace Z:/ in the filepath
+      gsub(
+        "Z:/",
+        paste0(
+          "/Users/",
+          Sys.info()["user"],
+          "/Library/CloudStorage/Egnyte-2cv"
+        ),
+        path
+      )
+    } else if (.Platform$OS.type == "windows") {
+      # replace /Users/.../Egnyte-thevalueengineers/
+      gsub(
+        "/Users.*Egnyte-2cv/",
+        "Z:/",
+        path
+      )
+    }
+  }
+  }

--- a/man/tve_path.Rd
+++ b/man/tve_path.Rd
@@ -4,10 +4,12 @@
 \alias{tve_path}
 \title{Generate an OS specific TVE filepath}
 \usage{
-tve_path(path)
+tve_path(path, dtag_company = "tve")
 }
 \arguments{
 \item{path}{File path to be converted}
+
+\item{dtag_company}{whether file path is for tve or 2cv}
 }
 \description{
 Paths on macOS don't use named drives, meaning a filepath from a Windows


### PR DESCRIPTION
To deal with different file paths used by 2cv projects. Need to add tests and more comprehensive package documentation. 

This closes [AB#374](https://dev.azure.com/DTAGroup/6c9b4dc1-4144-4323-8dfc-382c9c9f879e/_workitems/edit/374)